### PR TITLE
Add reference to publication Fröhlich et al. (2022) in modified SL function

### DIFF
--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL105.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL105.m
@@ -18,6 +18,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL105.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL105.m
@@ -18,7 +18,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL121.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL121.m
@@ -20,6 +20,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL121.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL121.m
@@ -20,7 +20,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL130.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL130.m
@@ -20,6 +20,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL130.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL130.m
@@ -20,7 +20,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL190.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL190.m
@@ -18,6 +18,8 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
+% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% https://doi.org/10.4401/ag-8781
 %
 %==========================================================================
 

--- a/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL190.m
+++ b/03_SL_getFileAndEQseconds/getFileAndEQseconds_SL190.m
@@ -18,7 +18,7 @@ function [FIsec, FIyyyy, EQsec, Omarker] = getFileAndEQseconds(F,eqin,offset)
 % GitHub: https://github.com/yvonnefroehlich/SplitLab-TemporalAlignment
 % => modifications to fix extraction of start time by SplitLab
 % (unconsidered milliseconds or seconds of start time)
-% publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
+% Publication: Fröhlich, Grund, Ritter (2022) Annals of Geophysics
 % https://doi.org/10.4401/ag-8781
 %
 %==========================================================================


### PR DESCRIPTION
This PR adds the reference to the publication Fröhlich, Grund, Ritter (2022) Annals of Geophysics to the scripts of the modified SplitLab function `getFileAndEQseconds_SS.m`.